### PR TITLE
fix turn order in round

### DIFF
--- a/pokerlib/_round.py
+++ b/pokerlib/_round.py
@@ -74,6 +74,8 @@ class AbstractRound(ABC):
 
     @property
     def starting_player_index(self):
+        if getattr(self, 'turn', Turn.PREFLOP) == Turn.PREFLOP:
+            return self.players.nextUnfoldedIndex(self.big_blind_player_index)
         return self.players.nextUnfoldedIndex(self.button)
     @property
     def last_aggressor_index(self):
@@ -81,13 +83,15 @@ class AbstractRound(ABC):
             self.current_index)
     @property
     def small_blind_player_index(self):
-        return (self.button - 1) % len(self.players)
+        return (self.button + 1) % len(self.players)
     @property
     def big_blind_player_index(self):
-        return (self.button - 2) % len(self.players)
+        return (self.button + 2) % len(self.players)
 
     @property
     def current_player(self):
+        if not isinstance(self.current_index, int):
+            self.current_index = self.current_index()
         return self.players[self.current_index]
 
     @property


### PR DESCRIPTION
Sure, here code for right order in turn.

But I had to add some dirty checks here to prevent errors from occurring in my docker container's python 3.10 environment.
I don’t know why, but on the local python 3.11 everything was fine and there were no errors when calling the current_player, but when I ran the code inside the docker container, the current_index turned out to be a function and not an int, that raised error; it happened in the first turn